### PR TITLE
Minify SVG versions - saves 30%

### DIFF
--- a/svg/markdown-mark-solid.svg
+++ b/svg/markdown-mark-solid.svg
@@ -1,9 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="208" height="128" viewBox="0 0 208 128">
-	<mask id="mask">
-		<rect style="fill:#fff" width="100%" height="100%" />
-		<path d="m 30,98 0,-68 20,0 20,25 20,-25 20,0 0,68 -20,0 0,-39 -20,25 -20,-25 0,39 z" />
-		<path d="m 155,98 -30,-33 20,0 0,-35 20,0 0,35 20,0 z" />
-	</mask>
-	<rect width="100%" height="100%" ry="15" mask="url(#mask)" />
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="208" height="128" viewBox="0 0 208 128"><mask id="a"><rect width="100%" height="100%" fill="#fff"/><path d="M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z"/></mask><rect width="100%" height="100%" ry="15" mask="url(#a)"/></svg>

--- a/svg/markdown-mark.svg
+++ b/svg/markdown-mark.svg
@@ -1,6 +1,1 @@
-<?xml version="1.0" encoding="utf-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" version="1.1" width="208" height="128" viewBox="0 0 208 128">
-	<rect style="fill:none;stroke:#000;stroke-width:10" width="198" height="118" x="5" y="5" ry="10" />
-	<path style="fill:#000" d="m 30,98 0,-68 20,0 20,25 20,-25 20,0 0,68 -20,0 0,-39 -20,25 -20,-25 0,39 z" />
-	<path style="fill:#000" d="m 155,98 -30,-33 20,0 0,-35 20,0 0,35 20,0 z" />
-</svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="208" height="128" viewBox="0 0 208 128"><rect width="198" height="118" x="5" y="5" ry="10" stroke="#000" stroke-width="10" fill="none"/><path d="M30 98v-68h20l20 25 20-25h20v68h-20v-39l-20 25-20-25v39zM155 98l-30-33h20v-35h20v35h20z"/></svg>


### PR DESCRIPTION
Reduced the size of the SVG versions. They're now 30% smaller. Looks exactly the same.
