### PR TITLE
Register the markdown-mark to Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,21 @@
+{
+  "name": "markdown-mark",
+  "version": "1.0.0",
+  "homepage": "https://github.com/markdown-extended/markdown-mark",
+  "authors": [
+    "dcurtis <hi@dustincurtis.com>"
+  ],
+  "description": "Marks to identify Markdown",
+  "main": "svg/markdown-mark.svg",
+  "keywords": [
+    "markdown"
+  ],
+  "license": "Public domain",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
I created a simple "bower.json" configuration file to prepare the repository to be registered in [Bower](http://bower.io/):
- the URL of the package should be updated if this is merged in original master
- the version number is arbitrary set to 1.0.0
- the "main file" is set to "svg/markdown-mark.svg"

This way, anyone can add it to its *bower components* and let Bower install it automatically ...

To finally register it, run: `bower register markdown-mark https://github.com/dcurtis/markdown-mark`